### PR TITLE
alternative trait imputation imputing traits from home (div) vs. away…

### DIFF
--- a/R/bootstrap_moment_plan.R
+++ b/R/bootstrap_moment_plan.R
@@ -2,47 +2,38 @@
 
 bootstrap_moment_plan <- drake_plan(
   
-  #impute traits for control, OTC, and pre-transplant
-  imputed_traits = {
-    imputed_traits_home <- community %>%
-      filter(year == min(year) | TTtreat %in% c("control", "local", "OTC")) %>% 
-      select(Site = originSiteID, blockID = originBlockID, turfID, year, TTtreat, Taxon = speciesName, cover) %>% 
-      trait_impute(traits = traits, 
-                   scale_hierarchy = c("Site", "blockID"),
-                   taxon_col = "Taxon", 
-                   value_col = "value_trans", 
-                   abundance_col = "cover", 
-                   other_col = c("TTtreat", "year", "turfID"))
-    
-    #impute traits for transplanted turfs
-    imputed_traits_transplant <- community %>%
-      filter(year > min(year), !TTtreat %in% c("control", "local", "OTC")) %>%
-      select(Site = destSiteID, blockID = destBlockID, turfID, year, TTtreat, Taxon = speciesName, cover) %>% 
-      trait_impute(traits = traits, 
-                   scale_hierarchy = c("Site", "blockID"),
-                   taxon_col = "Taxon",
-                   value_col = "value_trans",
-                   abundance_col = "cover",
-                   other_col = c("year", "TTtreat", "turfID"))
-    
-    
-    x <- bind_rows(
-      imputed_traits_home %>% select(everything()),#hack to deal with new vctrs 
-      imputed_traits_transplant %>% select(everything()))
-    class(x) <- class(imputed_traits_home)# recover traits
-      
-    attr(x, "attrib") <- attr(imputed_traits_home, "attrib")
-    x
-  },
+  #divergence
+  #impute traits for control and pre-transplant
+  imputed_traits_div = community %>%
+    select(Site = originSiteID, Location = originBlockID, turfID, year, TTtreat, Taxon = speciesName, cover) %>% 
+    trait_impute(traits = traits, 
+                 scale_hierarchy = c("Site", "Location"),
+                 taxon_col = "Taxon", 
+                 value_col = "value", 
+                 abundance_col = "cover", 
+                 other_col = c("TTtreat", "year", "turfID")),
+  
+  #convergence
+  #impute traits for control and pre-transplant
+  imputed_traits_conv = community %>%
+    select(Site = destSiteID, Location = destBlockID, turfID, year, TTtreat, Taxon = speciesName, cover) %>% 
+    trait_impute(traits = traits, 
+                 scale_hierarchy = c("Site", "Location"),
+                 taxon_col = "Taxon",
+                 value_col = "value",
+                 abundance_col = "cover",
+                 other_col = c("year", "TTtreat", "turfID")),
   
   #traits moments 
-  bootstrapped_trait_moments  = trait_np_bootstrap(imputed_traits, nrep = 100),
+  bootstrapped_trait_moments_div  = trait_np_bootstrap(imputed_traits_div, nrep = 100),
+  bootstrapped_trait_moments_conv  = trait_np_bootstrap(imputed_traits_conv, nrep = 100),
   
   #summarise bootstrap moments
-  summarised_boot_moments = trait_summarise_boot_moments(bootstrapped_trait_moments),
+  sum_boot_moment_div <- trait_summarise_boot_moments(bootstrapped_trait_moments_div),
+  sum_boot_moment_conv <- trait_summarise_boot_moments(bootstrapped_trait_moments_conv),
   
   #traits with climate
-  bootstrapped_trait_moments_climate = bootstrapped_trait_moments %>% 
+  bootstrapped_trait_moments_climate = bootstrapped_trait_moments_div %>% 
     left_join(env, by = c("Site" = "site")) %>% 
     filter(
       (logger == "otc" & TTtreat == "OTC") | (logger != "otc" & TTtreat != "OTC")) %>% 

--- a/R/plots_plan.R
+++ b/R/plots_plan.R
@@ -8,7 +8,7 @@ plot_plan <- drake_plan(
     labs(title = "Clean me"),
   
   #trait coverage
-  trait_coverage = autoplot(imputed_traits),
+  trait_coverage = autoplot(imputed_traits_div),
   
   #control means by site
   control_mean_boxplot = bootstrapped_trait_moments %>% 
@@ -28,7 +28,7 @@ plot_plan <- drake_plan(
   #kurtois
   
   
-  trait_mean_by_time_plot = bootstrapped_trait_moments %>% 
+  trait_mean_by_time_plot = bootstrapped_trait_moments_div %>% 
     filter(!TTtreat %in% c("control", "local", "OTC")) %>%
     group_by(year, turfID, TTtreat, trait, Site) %>% 
     summarise(mean = mean(mean)) %>% 


### PR DESCRIPTION
… site (conv)

Here is a suggestion for the trait impute using home or away plants. I don't know if we should call it div and conv or no plasticity and full plasticity. Using plasticity might be better, because div and conv will also be used later for checking for divergence and convergence for both the plastic and the non plastic case.... what do you think?

I think I changed the problem consistently, so in the boostrap and the ploting plan.